### PR TITLE
Add one-time webpack build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,20 @@ npm install
 
 ## Building
 
-Compile the project and watch for changes with:
+Build the project with:
 
 ```bash
 npm run build
 ```
 
-This command runs `webpack --watch` internally.
+Run the development build and watch for changes with:
+
+```bash
+npm run build:watch
+```
+
+Both commands output the bundled file into the `dist/` directory which is
+referenced by `index.html`.
 
 ## Running tests
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "webpack-cli": "^6.0.1"
   },
   "scripts": {
-    "build": "webpack --watch",
+    "build": "webpack",
+    "build:watch": "webpack --watch",
     "test": "karma start",
     "sendCoverage": "CODECLIMATE_REPO_TOKEN=ea0bc479adb6a18b2ab58cd62b95589bc6e3db2f24552303d1a39a2c3f98eb61 codeclimate-test-reporter < coverage/lcov.info"
   },


### PR DESCRIPTION
## Summary
- add non-watching build script and keep the existing watch command
- clarify build instructions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f3fab76588332948afc43aee806eb