### PR TITLE
Replace vulnerable nunjucks-loader

### DIFF
--- a/lib/loaders/runtime-shim.js
+++ b/lib/loaders/runtime-shim.js
@@ -1,0 +1,46 @@
+module.exports = function (nunjucks, env, obj, dependencies){
+
+    var oldRoot = obj.root;
+
+    obj.root = function( env, context, frame, runtime, ignoreMissing, cb ) {
+        var oldGetTemplate = env.getTemplate;
+        env.getTemplate = function (name, ec, parentName, ignoreMissing, cb) {
+            if( typeof ec === "function" ) {
+                cb = ec = false;
+            }
+            var _require = function (name) {
+                try {
+                    // add a reference to the already resolved dependency here
+                    return dependencies[name];
+                }
+                catch (e) {
+                    if (frame.get("_require")) {
+                        return frame.get("_require")(name);
+                    }
+                    else {
+                        console.warn('Could not load template "%s"', name);
+                    }
+                }
+            };
+
+            var tmpl = _require(name);
+            frame.set("_require", _require);
+
+            if( ec ) tmpl.compile();
+            cb( null, tmpl );
+        };
+
+        oldRoot(env, context, frame, runtime, ignoreMissing, function (err, res) {
+            env.getTemplate = oldGetTemplate;
+            cb( err, res );
+        });
+    };
+
+    var src = {
+        obj: obj,
+        type: 'code'
+    };
+
+    return new nunjucks.Template(src, env);
+
+};

--- a/lib/loaders/simple-nunjucks-loader.js
+++ b/lib/loaders/simple-nunjucks-loader.js
@@ -1,0 +1,34 @@
+const nunjucks = require('nunjucks');
+const path = require('path');
+const slash = require('slash');
+
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+
+  const name = slash(path.relative(this.rootContext || this.context, this.resourcePath));
+  let compiled = nunjucks.precompileString(source, { name });
+  compiled = compiled.replace(/window\.nunjucksPrecompiled/g, 'nunjucks.nunjucksPrecompiled');
+
+  const templateReg = /env\.getTemplate\(\"(.*?)\"/g;
+  let match;
+  const required = {};
+
+  let output = '';
+  output += 'var nunjucks = require("nunjucks/browser/nunjucks-slim");\n';
+  output += 'var env = nunjucks.currentEnv || (nunjucks.currentEnv = new nunjucks.Environment([]));\n';
+  output += 'var dependencies = nunjucks.webpackDependencies || (nunjucks.webpackDependencies = {});\n';
+  output += 'var shim = require("' + slash(path.resolve(__dirname, "./runtime-shim")) + '");\n';
+
+  while ((match = templateReg.exec(compiled))) {
+    const ref = match[1];
+    if (!required[ref]) {
+      output += 'dependencies["' + ref + '"] = require("' + ref + '");\n';
+      required[ref] = true;
+    }
+  }
+
+  output += compiled + '\n';
+  output += 'module.exports = shim(nunjucks, env, nunjucks.nunjucksPrecompiled["' + name + '"], dependencies);';
+
+  return output;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "chart.js": "^4.5.0",
         "commonjs": "^0.0.1",
         "nunjucks": "^3.2.4",
-        "nunjucks-loader": "^3.0.0"
+        "slash": "^1.0.0"
       },
       "devDependencies": {
         "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
@@ -1963,14 +1963,6 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
-    "node_modules/big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3442,14 +3434,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -4983,14 +4967,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "node_modules/json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -5897,30 +5873,6 @@
         }
       }
     },
-    "node_modules/nunjucks-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/nunjucks-loader/-/nunjucks-loader-3.0.0.tgz",
-      "integrity": "sha512-ew4gf8FuBi9DbMyksKStFzN8CWRtHuHFITS4KOTO0PJmEo7753HXJP51R6cGyfAuAEG0t+Qbh6di8vFYbnnJYw==",
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^0.2.12",
-        "slash": "~1.0.0"
-      },
-      "peerDependencies": {
-        "nunjucks": ">= 2.5.0 <= 4.0.0"
-      }
-    },
-    "node_modules/nunjucks-loader/node_modules/loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "dependencies": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
-      }
-    },
     "node_modules/nunjucks/node_modules/commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -5941,6 +5893,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7040,7 +6993,8 @@
     "node_modules/slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
     "chart.js": "^4.5.0",
     "commonjs": "^0.0.1",
     "nunjucks": "^3.2.4",
-    "nunjucks-loader": "^3.0.0"
+    "slash": "^1.0.0"
   },
   "devDependencies": {
+    "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
     "@types/jasmine": "^5.1.8",
     "@types/jquery": "^3.5.32",
     "@types/node": "^24.0.1",
     "css-loader": "^7.1.2",
     "d3": "^7.9.0",
     "es6-promise": "^4.2.8",
-    "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
     "jasmine": "^5.8.0",
     "jquery": "^3.7.1",
     "jsdom": "^20.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
         test: /\.tsx?$/,
       },
       {
-        loader: "nunjucks-loader",
+        loader: path.resolve(__dirname, "lib/loaders/simple-nunjucks-loader.js"),
         test: /\.(njk|nunjucks)$/,
       },
     ],


### PR DESCRIPTION
## Summary
- remove `nunjucks-loader` dependency
- add lightweight loader implementation in `lib/loaders`
- wire webpack to use the local loader
- add `slash` dependency

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f46d91db48332b5bfad6681114f45