### PR TITLE
Fix liquid loader path

### DIFF
--- a/lib/loaders/simple-liquid-loader.js
+++ b/lib/loaders/simple-liquid-loader.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = function(source) {
   this.cacheable && this.cacheable();
   const { resourcePath } = this;
-  const root = path.dirname(resourcePath);
+  const root = path.relative(process.cwd(), path.dirname(resourcePath));
   const tpl = JSON.stringify(source);
   const rootEscaped = JSON.stringify(root);
   return `const { Liquid } = require('liquidjs');


### PR DESCRIPTION
## Summary
- compute template root relative to project root to avoid absolute paths

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f5e7a5434833299cc1cbab57b2b4a