### PR TITLE
Fix Liquid templates calling class constructors

### DIFF
--- a/src/pages/pipe.ts
+++ b/src/pages/pipe.ts
@@ -5,7 +5,7 @@ import * as shuffles from "../shuffles";
 import * as sizes from "../sizes";
 import * as sorts from "../sorts/sorts";
 import * as valueTypes from "../valueTypes";
-import { createBoard } from "./utils";
+import { createBoard, sanitizeOptions } from "./utils";
 
 export const setUpPipe = (
   location: string,
@@ -21,10 +21,10 @@ export const setUpPipe = (
       sort: "Comb",
       valueType: "Integer",
     },
-    shuffles,
-    sizes,
-    sorts,
-    valueTypes,
+    shuffles: sanitizeOptions(shuffles, ["title"]),
+    sizes: sanitizeOptions(sizes, ["label"]),
+    sorts: sanitizeOptions(sorts, ["title"]),
+    valueTypes: sanitizeOptions(valueTypes, ["title"]),
   });
   return html;
 };

--- a/src/pages/profile.ts
+++ b/src/pages/profile.ts
@@ -6,7 +6,7 @@ import * as sizes from "../sizes";
 import { BaseSort } from "../sorts/baseSort";
 import * as sorts from "../sorts/sorts";
 import * as valueTypes from "../valueTypes";
-import { createBoard } from "./utils";
+import { createBoard, sanitizeOptions } from "./utils";
 
 export const setUpProfile = (
   location: string,
@@ -22,10 +22,10 @@ export const setUpProfile = (
       sort: "Comb",
       value: "Integer",
     },
-    shuffles,
-    sizes,
-    sorts,
-    valueTypes,
+    shuffles: sanitizeOptions(shuffles, ["title"]),
+    sizes: sanitizeOptions(sizes, ["label"]),
+    sorts: sanitizeOptions(sorts, ["title"]),
+    valueTypes: sanitizeOptions(valueTypes, ["title"]),
   });
   return html;
 };

--- a/src/pages/scatter.ts
+++ b/src/pages/scatter.ts
@@ -4,7 +4,7 @@ import * as sizes from "../sizes";
 import * as sorts from "../sorts/sorts";
 import * as valueTypes from "../valueTypes";
 import { BoardDisplay } from "./../display/board";
-import { createBoard } from "./utils";
+import { createBoard, sanitizeOptions } from "./utils";
 
 export const setUpScatter = (
   location: string,
@@ -20,10 +20,10 @@ export const setUpScatter = (
       sort: "Gravity",
       valueType: "Integer",
     },
-    shuffles,
-    sizes,
-    sorts,
-    valueTypes,
+    shuffles: sanitizeOptions(shuffles, ["title"]),
+    sizes: sanitizeOptions(sizes, ["label"]),
+    sorts: sanitizeOptions(sorts, ["title"]),
+    valueTypes: sanitizeOptions(valueTypes, ["title"]),
   });
   return html;
 };

--- a/src/pages/single.ts
+++ b/src/pages/single.ts
@@ -1,7 +1,7 @@
 import * as jquery from "jquery";
 import { Board, Verbosity } from "../board";
 import { BoardDisplay } from "../display/board";
-import { IShuffle, RandomShuffle } from "../shuffles";
+import { IShuffle } from "../shuffles";
 import * as shuffles from "../shuffles";
 import { _25 } from "../sizes";
 import { BaseSort } from "../sorts/baseSort";
@@ -9,6 +9,7 @@ import { Comb } from "../sorts/sorts";
 import * as sorts from "../sorts/sorts";
 import { Integer, IValueType } from "../valueTypes";
 import { ISize } from "./../sizes";
+import { sanitizeOptions } from "./utils";
 
 const defaults = {
   shuffle: "RandomShuffle",
@@ -20,8 +21,8 @@ export const setUpSingle = () => {
   const tpl = require("../../templates/single.liquid");
   const html = tpl({
     defaults,
-    shuffles,
-    sorts,
+    shuffles: sanitizeOptions(shuffles, ["title"]),
+    sorts: sanitizeOptions(sorts, ["title"]),
   });
   return html;
 };

--- a/src/pages/stick.ts
+++ b/src/pages/stick.ts
@@ -11,7 +11,7 @@ import { BoardDisplay } from "./../display/board";
 import { IShuffle } from "./../shuffles/abstract";
 import { ISize } from "./../sizes";
 import { IValueType } from "./../valueTypes";
-import { createBoard } from "./utils";
+import { createBoard, sanitizeOptions } from "./utils";
 
 const index = 0;
 
@@ -28,10 +28,10 @@ export const setUpStick = (
       sort: "Comb",
       valueType: "Integer",
     },
-    shuffles,
-    sizes,
-    sorts,
-    valueTypes,
+    shuffles: sanitizeOptions(shuffles, ["title"]),
+    sizes: sanitizeOptions(sizes, ["label"]),
+    sorts: sanitizeOptions(sorts, ["title"]),
+    valueTypes: sanitizeOptions(valueTypes, ["title"]),
   });
   return html;
 };

--- a/src/pages/utils.ts
+++ b/src/pages/utils.ts
@@ -39,3 +39,18 @@ export const createBoard = (display: AbstractDisplay) => {
   });
   index++;
 };
+
+export const sanitizeOptions = (
+  obj: { [key: string]: any },
+  props: string[],
+) => {
+  return Object.entries(obj).map(([key, value]) => {
+    const clean: { [key: string]: any } = {};
+    props.forEach((p) => {
+      if (value && Object.prototype.hasOwnProperty.call(value, p)) {
+        clean[p] = value[p];
+      }
+    });
+    return [key, clean];
+  });
+};


### PR DESCRIPTION
## Summary
- add `sanitizeOptions` utility to strip out class values for templates
- use sanitized options for sort/shuffle/size/valueType data across pages

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f61875c1483329661d0c79771cb1e